### PR TITLE
chore(astro-fe): unify strapi env vars into one

### DIFF
--- a/packages/astro-frontend/src/server/config/strapiConfig.ts
+++ b/packages/astro-frontend/src/server/config/strapiConfig.ts
@@ -2,13 +2,11 @@ import { z } from "zod";
 
 export const StrapiApiConfig = z
   .object({
-    STRAPI_API_URL: z.string(),
-    STRAPI_API_PORT: z.coerce.number().min(1001),
+    STRAPI_API_ENDPOINT: z.string(),
     STRAPI_API_TOKEN: z.string(),
   })
   .transform((c) => ({
-    strapiApiUrl: c.STRAPI_API_URL,
-    strapiApiPort: c.STRAPI_API_PORT,
+    strapiApiEndpoint: c.STRAPI_API_ENDPOINT,
     strapiApiToken: c.STRAPI_API_TOKEN,
   }));
 

--- a/packages/astro-frontend/src/server/services/index.ts
+++ b/packages/astro-frontend/src/server/services/index.ts
@@ -21,7 +21,6 @@ export const sqlService: ReturnType<typeof publicModelServiceBuilder> =
 const strapiConfig = StrapiApiConfig.parse(import.meta.env);
 
 export const strapiService = strapiServiceBuilder(
-  strapiConfig.strapiApiUrl,
-  strapiConfig.strapiApiPort,
+  strapiConfig.strapiApiEndpoint,
   strapiConfig.strapiApiToken
 );

--- a/packages/astro-frontend/src/server/services/strapiService.ts
+++ b/packages/astro-frontend/src/server/services/strapiService.ts
@@ -1,14 +1,17 @@
 import { StrapiArticle, StrapiEntityList } from "../types/stripe.js";
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type, max-params
-export function strapiServiceBuilder(url: string, port: number, token: string) {
+export function strapiServiceBuilder(endpoint: string, token: string) {
   return {
     async getArticles(): Promise<StrapiEntityList<StrapiArticle>> {
-      const response = await fetch(`${url}:${port}/api/articles`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      const response = await fetch(
+        `${endpoint.endsWith('/') ? endpoint : endpoint + '/'}api/articles`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
 
       return response.json();
     },


### PR DESCRIPTION
As per discussions with the Infrastructure Team, this PR unifies the previously made two env variables for the Astro FE package into a single one.

from:
STRAPI_API_URL
STRAPI_API_PORT
to  -> STRAPI_API_ENDPOINT