### PR TITLE
fix: add missing key prop to catalog external links list (PIN-10606)

### DIFF
--- a/packages/astro-frontend/src/components/EServiceCatalog/EServiceCatalog.tsx
+++ b/packages/astro-frontend/src/components/EServiceCatalog/EServiceCatalog.tsx
@@ -63,6 +63,7 @@ export const EServiceCatalog: React.FC<{
           <div className="p-3">
             {strapiCatalogContent.Links.SingleLink.map((singleLink) => (
               <a
+                key={singleLink.LinkURL}
                 data-mp-external-link-id={singleLink.MixpanelExternalLinkId}
                 data-mp-external-link-description={
                   singleLink.MixpanelExternalLinkDescription


### PR DESCRIPTION
## Jira Issue
[PIN-10606](https://pagopa.atlassian.net/browse/PIN-10606)

## Context
- The catalog page (`/it/catalogo`) logs a React "Each child in a list should have a unique key prop" warning on every render, because the list of external resource links has no key.

## Services Affected
- astro-frontend

## Key Changes
- `EServiceCatalog.tsx`: added a key prop (derived from `LinkURL`) to the mapped external link elements.

## Checklist
- [x] Branch name contains the Jira key
- [x] PR title follows the format: `type: description (KEY)`
- [ ] Service labels applied
- [ ] Fix Version set in Jira (if required)
- [ ] API and integration tests updated (if required)
- [ ] OpenAPI spec updated (if required)
- [ ] Bruno collection or endpoint definition updated (if required)


[PIN-10606]: https://pagopa.atlassian.net/browse/PIN-10606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ